### PR TITLE
Added configuration `header_string` and `footer_string`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ Formats Sprintf(Java String#format) files for other file output plugins.
 - **format**: format (string, required)
 - **column_keys**: column_keys (array, required)
 - **null_string**: null_string (string, default: '')
+- **header_string**: format (string, default: '')
+- **footer_string**: format (string, default: '')
 
 ## Example
+
+json list
 
 ```yaml
 out:
@@ -21,6 +25,22 @@ out:
     type: sprintf
     null_string: null
     format: "    - { id: %s, url: '%s' }\n"
+    column_keys:
+      - id
+      - url
+```
+
+xml
+
+```yaml
+out:
+  type: any output input plugin type
+  formatter:
+    type: sprintf
+    null_string: null
+    header_string: "<?xml version=\"1.0\" encodint=\"UTF-8\" ?><response><users>"
+    footer_string: "</users></response>"
+    format: "<user><id><![CDATA[%s]]></id><url><![CDATA[%s]]></url></user>\n"
     column_keys:
       - id
       - url

--- a/src/main/java/org/embulk/formatter/sprintf/SprintfFormatterPlugin.java
+++ b/src/main/java/org/embulk/formatter/sprintf/SprintfFormatterPlugin.java
@@ -40,6 +40,14 @@ public class SprintfFormatterPlugin
         @Config("null_string")
         @ConfigDefault("\"\"")
         public String getNullString();
+
+        @Config("header_string")
+        @ConfigDefault("\"\"")
+        public String getHeaderString();
+
+        @Config("footer_string")
+        @ConfigDefault("\"\"")
+        public String getFooterString();
     }
 
     @Override
@@ -68,8 +76,19 @@ public class SprintfFormatterPlugin
         final LineEncoder encoder = new LineEncoder(output, task);
         final String nullString = task.getNullString();
         final Schema outputSchema = getOutputSchema(task.getColumnKeys(), inputSchema);
+        final String headerString = task.getHeaderString();
+        final String footerString = task.getFooterString();
 
         encoder.nextFile();
+
+        logger.debug("header_string => {}", headerString);
+        logger.debug("footer_string => {}", footerString);
+
+        // write header string
+        if (!headerString.isEmpty()) {
+            encoder.addText(headerString);
+            encoder.addNewLine();
+        }
 
         return new PageOutput() {
             private final PageReader pageReader = new PageReader(inputSchema);
@@ -106,6 +125,13 @@ public class SprintfFormatterPlugin
 
             public void finish()
             {
+
+                // write footer string
+                if (!footerString.isEmpty()) {
+                    encoder.addText(footerString);
+                    encoder.addNewLine();
+                }
+
                 encoder.finish();
             }
 


### PR DESCRIPTION
It is useful when output Semi-structured data(ex: json, xml, yaml).

example:

```xml
<xml><users>         <!-- header string -->
    <user>...</user> <!-- sprintf string -->
    <user>...</user> <!-- sprintf string -->
</users></xml>     <!-- footer string -->
```

```yaml
root:                        # header string
  users:                     # header string
    - { name: xxx, id: yyy } # sprintf string
    - { name: xxx, id: yyy } # sprintf string
```
